### PR TITLE
add private weeks endpoints for baby and mom states

### DIFF
--- a/src/controllers/weeks/weeksController.js
+++ b/src/controllers/weeks/weeksController.js
@@ -1,0 +1,47 @@
+import createHttpError from "http-errors";
+import { getPregnancyProgress } from "../../utils/getPregnancyProgress.js";
+import { getBabyStateByWeek } from "../../services/weeks/getWeekState.js";
+import { getMomStateByWeek } from "../../services/weeks/getWeekState.js";
+
+export const getBabyStateController = async (req, res) => {
+  const { dueDate } = req.user;
+
+  if (!dueDate) {
+    throw createHttpError(400, "Due date is required");
+  }
+
+  const { currentWeek } = getPregnancyProgress(dueDate);
+
+  if (!currentWeek || currentWeek < 1 || currentWeek > 42) {
+    throw createHttpError(400, "Invalid pregnancy week");
+  }
+
+  const data = await getBabyStateByWeek(currentWeek);
+
+  res.status(200).json({
+    status: 200,
+    message: "Successfully found baby state",
+    data,
+  });
+};
+export const getMomStateController = async (req, res) => {
+  const { dueDate } = req.user;
+
+  if (!dueDate) {
+    throw createHttpError(400, "Due date is required");
+  }
+
+  const { currentWeek } = getPregnancyProgress(dueDate);
+
+  if (!currentWeek || currentWeek < 1 || currentWeek > 42) {
+    throw createHttpError(400, "Invalid pregnancy week");
+  }
+
+  const data = await getMomStateByWeek(currentWeek);
+
+  res.status(200).json({
+    status: 200,
+    message: "Successfully found mom state",
+    data,
+  });
+};

--- a/src/models/baby_state.js
+++ b/src/models/baby_state.js
@@ -1,5 +1,21 @@
 import { Schema, model } from "mongoose";
 
-const babyStateSchema = new Schema({});
+const babyStateSchema = new Schema(
+  {
+    weekNumber: { type: Number, required: true, unique: true },
+    analogy: { type: String, default: null },
+    babySize: { type: Number, default: 0 },
+    babyWeight: { type: Number, default: 0 },
+    image: { type: String, required: true },
+    babyActivity: { type: String, required: true },
+    babyDevelopment: { type: String, required: true },
+    interestingFact: { type: String, required: true },
+    momDailyTips: { type: [String], default: [] },
+  },
+  {
+    versionKey: false,
+    collection: "baby_states",
+  },
+);
 
 export const babyStateModel = model("baby_state", babyStateSchema);

--- a/src/models/mom_state.js
+++ b/src/models/mom_state.js
@@ -1,5 +1,23 @@
 import { Schema, model } from "mongoose";
 
-const momStateSchema = new Schema({});
+const momStateSchema = new Schema(
+  {
+    weekNumber: { type: Number, required: true, unique: true },
+    feelings: {
+      states: { type: [String], default: [] },
+      sensationDescr: { type: String, required: true },
+    },
+    comfortTips: [
+      {
+        category: { type: String, required: true },
+        tip: { type: String, required: true },
+      },
+    ],
+  },
+  {
+    versionKey: false,
+    collection: "mom_states",
+  },
+);
 
 export const momStateModel = model("mom_state", momStateSchema);

--- a/src/routes/weeksRouter.js
+++ b/src/routes/weeksRouter.js
@@ -1,5 +1,12 @@
 import { Router } from "express";
+import { authenticate } from "../middleware/authenticate.js";
+
+import {
+  getBabyStateController,
+  getMomStateController,
+} from "../controllers/weeks/weeksController.js";
 
 const weeksRouter = Router();
-
+weeksRouter.get("/baby", authenticate, getBabyStateController);
+weeksRouter.get("/mom", authenticate, getMomStateController);
 export default weeksRouter;

--- a/src/services/weeks/getWeekState.js
+++ b/src/services/weeks/getWeekState.js
@@ -1,0 +1,23 @@
+import createHttpError from "http-errors";
+import { babyStateModel } from "../../models/baby_state.js";
+import { momStateModel } from "../../models/mom_state.js";
+
+export const getBabyStateByWeek = async (weekNumber) => {
+  const babyState = await babyStateModel.findOne({ weekNumber }).lean();
+
+  if (!babyState) {
+    throw createHttpError(404, `Baby state for week ${weekNumber} not found`);
+  }
+
+  return babyState;
+};
+
+export const getMomStateByWeek = async (weekNumber) => {
+  const momState = await momStateModel.findOne({ weekNumber }).lean();
+
+  if (!momState) {
+    throw createHttpError(404, `Mom state for week ${weekNumber} not found`);
+  }
+
+  return momState;
+};


### PR DESCRIPTION
Реалізовано приватні ендпоінти:
- GET /api/weeks/baby
- GET /api/weeks/mom

Що зроблено:
- додано отримання даних про розвиток малюка за поточним тижнем вагітності
- додано отримання даних про стан мами за поточним тижнем вагітності
- реалізовано сервіс пошуку даних за weekNumber (який береться з утіліти Анастасії)
- підключено маршрути в weeksRouter (сюди ж будуть підключатися  роути Віталії)
- використано розрахунок поточного тижня на основі dueDate користувача (який береться, коли модель Юзера від Андрія :)) )

Примітка:
- ендпоінти працюють для авторизованого користувача, потрібна логіка авториації
- дані беруться з колекцій baby_states та mom_states