### PR TITLE
add dashboard pregnancy progress util

### DIFF
--- a/src/services/weeks/getWeeksDashboard.js
+++ b/src/services/weeks/getWeeksDashboard.js
@@ -1,0 +1,68 @@
+import createHttpError from "http-errors";
+import { babyStateModel } from "../../models/baby_state.js";
+import { getDashboardPregnancyProgress } from "../../utils/getDashboardPregnancyProgress.js";
+
+const LAST_WEEK = 40;
+const DEFAULT_PUBLIC_WEEK = 1;
+
+const getPublicDaysUntilDueDate = () => {
+  return (LAST_WEEK - DEFAULT_PUBLIC_WEEK) * 7;
+};
+
+export const getPublicWeeksDashboardData = async () => {
+  const currentWeek = DEFAULT_PUBLIC_WEEK;
+  const daysUntilDueDate = getPublicDaysUntilDueDate();
+
+  const babyState = await babyStateModel.findOne({ weekNumber: currentWeek }).lean();
+
+  if (!babyState) {
+    throw createHttpError(
+      404,
+      `Dashboard data for week ${currentWeek} not found`,
+    );
+  }
+
+  return {
+    weekNumber: currentWeek,
+    daysUntilDueDate,
+    baby: {
+      analogy: babyState.analogy,
+      babySize: babyState.babySize,
+      babyWeight: babyState.babyWeight,
+      image: babyState.image,
+      interestingFact: babyState.interestingFact,
+    },
+    momTip: babyState.momDailyTips?.[0] ?? null,
+  };
+};
+
+export const getPrivateWeeksDashboardData = async (dueDate) => {
+  if (!dueDate) {
+    throw createHttpError(400, "Due date is required");
+  }
+
+  const { currentWeek, daysUntilDueDate, dayIndexInWeek } =
+    getDashboardPregnancyProgress(dueDate);
+
+  const babyState = await babyStateModel.findOne({ weekNumber: currentWeek }).lean();
+
+  if (!babyState) {
+    throw createHttpError(
+      404,
+      `Dashboard data for week ${currentWeek} not found`,
+    );
+  }
+
+  return {
+    weekNumber: currentWeek,
+    daysUntilDueDate,
+    baby: {
+      analogy: babyState.analogy,
+      babySize: babyState.babySize,
+      babyWeight: babyState.babyWeight,
+      image: babyState.image,
+      interestingFact: babyState.interestingFact,
+    },
+    momTip: babyState.momDailyTips?.[dayIndexInWeek] ?? null,
+  };
+};

--- a/src/utils/getDashboardPregnancyProgress.js
+++ b/src/utils/getDashboardPregnancyProgress.js
@@ -1,0 +1,43 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+const TOTAL_WEEKS = 40;
+const TOTAL_DAYS = TOTAL_WEEKS * 7;
+
+const normalizeDate = (date) => {
+  const normalized = new Date(date);
+  normalized.setHours(0, 0, 0, 0);
+  return normalized;
+};
+
+export const getDashboardPregnancyProgress = (dueDate) => {
+  if (!dueDate) {
+    return {
+      currentWeek: 1,
+      daysUntilDueDate: (TOTAL_WEEKS - 1) * 7,
+      dayIndexInWeek: 0,
+    };
+  }
+
+  const due = normalizeDate(dueDate);
+
+  if (Number.isNaN(due.getTime())) {
+    throw new Error("Invalid dueDate");
+  }
+
+  const today = normalizeDate(new Date());
+  const diffMs = due.getTime() - today.getTime();
+  const daysUntilDueDate = Math.ceil(diffMs / DAY_MS);
+
+  const pregnancyDayIndex = Math.min(
+    TOTAL_DAYS - 1,
+    Math.max(0, TOTAL_DAYS - daysUntilDueDate - 1),
+  );
+
+  const currentWeek = Math.floor(pregnancyDayIndex / 7) + 1;
+  const dayIndexInWeek = pregnancyDayIndex % 7;
+
+  return {
+    currentWeek,
+    daysUntilDueDate: Math.max(0, daysUntilDueDate),
+    dayIndexInWeek,
+  };
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,1 +1,2 @@
 export { getPregnancyProgress } from "./getPregnancyProgress.js";
+export { getDashboardPregnancyProgress } from "./getDashboardPregnancyProgress.js";


### PR DESCRIPTION
Додано окрему dashboard-логіку для розрахунку прогресу вагітності без змін у базовому getPregnancyProgress. Реалізовано підтримку dayIndexInWeek для щоденних momDailyTips